### PR TITLE
fix ExecuteProcess return value and disable sigchld handler

### DIFF
--- a/src/GAP.jl
+++ b/src/GAP.jl
@@ -96,6 +96,13 @@ function initialize(argv::Vector{String})
     # TODO: turn this into a proper libgap API
     unsafe_store!(cglobal((:SyLoadSystemInitFile, libgap), Int64), 0)
 
+    # remember sigchld handler
+    if Sys.isbsd() || Sys.islinux()
+        sigchld = Sys.isbsd() ? 20 : 17
+        # nullptr == SIG_DFL
+        prev_sigchld_hdl = ccall(:signal, Ptr{Cvoid}, (Cint, Ptr{Cvoid}), sigchld, Ptr{Cvoid}(0))
+    end
+
     ccall(
         (:GAP_Initialize, libgap),
         Cvoid,
@@ -106,6 +113,13 @@ function initialize(argv::Vector{String})
         error_handler_func,
         handle_signals,
     )
+
+    # restore previous sigchld handler
+    # the one from gap should not be necessary with the replaced ExecuteProcess
+    # it also interferes badly with julia subprocess handling on macos because of the waitpid(-1)
+    if Sys.isbsd() || Sys.islinux()
+        gap_chld_hdl = ccall(:signal, Ptr{Cvoid}, (Cint, Ptr{Cvoid}), sigchld, prev_sigchld_hdl)
+    end
 
     # HACK HACK HACK workaround
     Base.GC.gc(true)

--- a/src/exec.jl
+++ b/src/exec.jl
@@ -54,6 +54,6 @@ function GAP_ExecuteProcess(dir::String, prg::String, fin::Int, fout::Int, args:
     # TODO: verify `dir` is a valid dir?
     cd(dir) do
         res = run(pipeline(ignorestatus(`$prg $args`), stdin=fin, stdout=fout))
-        return res == 255 ? GAP.Globals.Fail : res
+        return res.exitcode == 255 ? GAP.Globals.Fail : res.exitcode
     end
 end


### PR DESCRIPTION
This seems to work with julia master on macos.

Note: this PR targets the branch from https://github.com/oscar-system/GAP.jl/pull/726 and I merged some parts of master.